### PR TITLE
Clarify sync descriptions for Jellyfin and Emby

### DIFF
--- a/webui/frontend/src/locales/de/translation.json
+++ b/webui/frontend/src/locales/de/translation.json
@@ -90,11 +90,11 @@
       },
       "syncJellyfin": {
         "title": "Jellyfin Sync",
-        "description": "Poster zu Jellyfin synchronisieren"
+        "description": "Plex Poster zu Jellyfin synchronisieren"
       },
       "syncEmby": {
         "title": "Emby Sync",
-        "description": "Poster zu Emby synchronisieren"
+        "description": "Plex Poster zu Emby synchronisieren"
       }
     },
     "manual": {

--- a/webui/frontend/src/locales/en/translation.json
+++ b/webui/frontend/src/locales/en/translation.json
@@ -90,11 +90,11 @@
       },
       "syncJellyfin": {
         "title": "Sync Jellyfin",
-        "description": "Sync posters to Jellyfin"
+        "description": "Sync plex posters to Jellyfin"
       },
       "syncEmby": {
         "title": "Sync Emby",
-        "description": "Sync posters to Emby"
+        "description": "Sync plex posters to Emby"
       }
     },
     "manual": {

--- a/webui/frontend/src/locales/fr/translation.json
+++ b/webui/frontend/src/locales/fr/translation.json
@@ -90,11 +90,11 @@
       },
       "syncJellyfin": {
         "title": "Sync Jellyfin",
-        "description": "Synchroniser les affiches vers Jellyfin"
+        "description": "Synchroniser les affiches Plex vers Jellyfin"
       },
       "syncEmby": {
         "title": "Sync Emby",
-        "description": "Synchroniser les affiches vers Emby"
+        "description": "Synchroniser les affiches Plex vers Emby"
       }
     },
     "manual": {

--- a/webui/frontend/src/locales/it/translation.json
+++ b/webui/frontend/src/locales/it/translation.json
@@ -90,11 +90,11 @@
       },
       "syncJellyfin": {
         "title": "Sincronizza Jellyfin",
-        "description": "Sincronizza le locandine su Jellyfin"
+        "description": "Sincronizza i poster di Plex su Jellyfin"
       },
       "syncEmby": {
         "title": "Sincronizza Emby",
-        "description": "Sincronizza le locandine su Emby"
+        "description": "Sincronizza i poster di Plex su Emby"
       }
     },
     "manual": {

--- a/webui/frontend/src/locales/pt/translation.json
+++ b/webui/frontend/src/locales/pt/translation.json
@@ -90,11 +90,11 @@
       },
       "syncJellyfin": {
         "title": "Sincronizar Jellyfin",
-        "description": "Sincronizar cartazes para o Jellyfin"
+        "description": "Sincronizar os posters do Plex para o Jellyfin"
       },
       "syncEmby": {
         "title": "Sincronizar Emby",
-        "description": "Sincronizar cartazes para o Emby"
+        "description": "Sincronizar os posters do Plex para o Emby"
       }
     },
     "manual": {


### PR DESCRIPTION
Updated translation strings in multiple languages to specify that the sync actions transfer Plex posters to Jellyfin and Emby, improving clarity for users.