### PR TITLE
$lang check always true

### DIFF
--- a/Posterizarr.ps1
+++ b/Posterizarr.ps1
@@ -137,7 +137,7 @@ function GetTMDBLogo {
         if ($response) {
             if ($response.images.logos) {
                 foreach ($lang in $global:LogoLanguageOrder) {
-                    if ($lang -ne 'null' -or $lang -ne 'xx') {
+                    if ($lang -ne 'null' -and $lang -ne 'xx') {
                         if ($global:UseClearlogo -eq 'true'){
                             $FavPoster = ($response.images.logos | Where-Object iso_639_1 -eq $lang)
                         }
@@ -151,7 +151,7 @@ function GetTMDBLogo {
                             $posterpath = (($FavPoster | Sort-Object $global:TMDBVoteSorting -Descending)[0]).file_path
                         }
                         $global:LogoUrl = "https://image.tmdb.org/t/p/original$posterpath"
-                        if ($lang -ne 'null' -or $lang -ne 'xx') {
+                        if ($lang -ne 'null' -and $lang -ne 'xx') {
                             Write-Entry -Subtext "Found Logo with Language '$lang' on TMDB" -Path $global:configLogging -Color Blue -log Info
                         }
                         $global:LogoLanguage = $lang


### PR DESCRIPTION
condition is always true no matter what $lang is.  Changing to -and allows calls to be skipped if false.

## Checklist

- [N] Is versioning adapted in script?
- [N] Is versioning adapted in Release.txt?
- [X] I didn't upload any images to the repository.
- [X] I have tested the changed code on:
  - [ ] Docker
  - [X] Windows
  - [ ] Linux
  - [ ] macOS
  - [ ] Unraid
