### PR TITLE
Per-library language overrides + fix two related bugs found while implementing it

### DIFF
--- a/Posterizarr.ps1
+++ b/Posterizarr.ps1
@@ -5817,6 +5817,17 @@ function MassDownloadPlexArtwork {
                         $Titletext = $entry.title
                     }
                 }
+                if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                    # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                    # which left Titletext blank above and broke the metadata search entirely.
+                    # Fall back to whichever of title/originalTitle actually has a value.
+                    if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                        $Titletext = $entry.title
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                        $Titletext = $entry.originalTitle
+                    }
+                }
 
                 if ($LibraryFolders -eq 'true') {
                     $LibraryName = $entry.'Library Name'
@@ -6148,6 +6159,17 @@ function MassDownloadPlexArtwork {
                 }
                 else {
                     $Titletext = $entry.title
+                }
+            }
+            if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                # which left Titletext blank above and broke the metadata search entirely.
+                # Fall back to whichever of title/originalTitle actually has a value.
+                if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                    $Titletext = $entry.title
+                }
+                elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                    $Titletext = $entry.originalTitle
                 }
             }
 
@@ -7659,6 +7681,54 @@ Initialize-LanguageSettings -SettingName "PreferredLanguageOrder"           -Lab
 Initialize-LanguageSettings -SettingName "PreferredSeasonLanguageOrder"     -Label "Season"
 Initialize-LanguageSettings -SettingName "PreferredTCLanguageOrder"         -Label "TC"
 Initialize-LanguageSettings -SettingName "PreferredBackgroundLanguageOrder" -Label "Background"
+
+# --- Library-specific language override support ---
+$global:LibraryLanguageOverrides = $config.ApiPart.LibraryLanguageOverrides
+if (-not $global:LibraryLanguageOverrides) { $global:LibraryLanguageOverrides = @{} }
+
+# Stash the validated server-wide defaults so per-library overrides can fall back to them
+$global:DefaultPreferredLanguageOrder = $global:PreferredLanguageOrder
+$global:DefaultPreferredSeasonLanguageOrder = $global:PreferredSeasonLanguageOrder
+$global:DefaultPreferredTCLanguageOrder = $global:PreferredTCLanguageOrder
+$global:DefaultPreferredBackgroundLanguageOrder = $global:PreferredBackgroundLanguageOrder
+$global:DefaultLogoLanguageOrder = $global:LogoLanguageOrder
+
+function Set-LibraryLanguageOverride {
+    param([string]$LibraryName)
+
+    $override = $null
+    if ($global:LibraryLanguageOverrides -and ($global:LibraryLanguageOverrides.PSObject.Properties.Name -contains $LibraryName)) {
+        $override = $global:LibraryLanguageOverrides.$LibraryName
+    }
+
+    $map = [ordered]@{
+        "PreferredLanguageOrder"           = @{ Label = "Poster";     Default = $global:DefaultPreferredLanguageOrder }
+        "PreferredSeasonLanguageOrder"     = @{ Label = "Season";     Default = $global:DefaultPreferredSeasonLanguageOrder }
+        "PreferredTCLanguageOrder"         = @{ Label = "TC";         Default = $global:DefaultPreferredTCLanguageOrder }
+        "PreferredBackgroundLanguageOrder" = @{ Label = "Background"; Default = $global:DefaultPreferredBackgroundLanguageOrder }
+    }
+
+    foreach ($key in $map.Keys) {
+        $value = $map[$key].Default
+        if ($override -and ($override.PSObject.Properties.Name -contains $key)) {
+            $value = $override.$key
+        }
+        Set-Variable -Name $key -Scope Global -Value $value
+        Initialize-LanguageSettings -SettingName $key -Label $map[$key].Label
+    }
+
+    $logoValue = $global:DefaultLogoLanguageOrder
+    if ($override -and ($override.PSObject.Properties.Name -contains "LogoLanguageOrder")) {
+        $logoValue = $override.LogoLanguageOrder
+    }
+    Set-Variable -Name "LogoLanguageOrder" -Scope Global -Value $logoValue
+
+    if ($override) {
+        Write-Entry -Subtext "Applied language override for library '$LibraryName'" -Path $global:configLogging -Color Cyan -log Info
+    }
+}
+# --- end library-specific language override support ---
+
 
 # default to TMDB if favprovider missing
 if (!$global:FavProvider) {
@@ -10544,6 +10614,17 @@ Elseif ($Tautulli) {
                             $Titletext = $entry.title
                         }
                     }
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
+                        }
+                    }
 
                     if ($LibraryFolders -eq 'true') {
                         $LibraryName = $entry.'Library Name'
@@ -11976,6 +12057,17 @@ Elseif ($Tautulli) {
                     }
                     else {
                         $Titletext = $entry.title
+                    }
+                }
+                if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                    # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                    # which left Titletext blank above and broke the metadata search entirely.
+                    # Fall back to whichever of title/originalTitle actually has a value.
+                    if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                        $Titletext = $entry.title
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                        $Titletext = $entry.originalTitle
                     }
                 }
 
@@ -16503,6 +16595,17 @@ Elseif ($ArrTrigger) {
                                 $Titletext = $entry.title
                             }
                         }
+                        if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                            # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                            # which left Titletext blank above and broke the metadata search entirely.
+                            # Fall back to whichever of title/originalTitle actually has a value.
+                            if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                                $Titletext = $entry.title
+                            }
+                            elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                                $Titletext = $entry.originalTitle
+                            }
+                        }
 
                         if ($LibraryFolders -eq 'true') {
                             $LibraryName = $entry.'Library Name'
@@ -17807,6 +17910,17 @@ Elseif ($ArrTrigger) {
                         }
                         else {
                             $Titletext = $entry.title
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
                         }
                     }
 
@@ -21370,6 +21484,17 @@ Elseif ($ArrTrigger) {
                                 $Titletext = $entry.title
                             }
                         }
+                        if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                            # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                            # which left Titletext blank above and broke the metadata search entirely.
+                            # Fall back to whichever of title/originalTitle actually has a value.
+                            if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                                $Titletext = $entry.title
+                            }
+                            elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                                $Titletext = $entry.originalTitle
+                            }
+                        }
 
                         if ($LibraryFolders -eq 'true') {
                             $LibraryName = $entry.'Library Name'
@@ -22800,6 +22925,17 @@ Elseif ($ArrTrigger) {
                         }
                         else {
                             $Titletext = $entry.title
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
                         }
                     }
 
@@ -28543,6 +28679,17 @@ Elseif ($OtherMediaServerUrl -and $OtherMediaServerApiKey -and $UseOtherMediaSer
                             $Titletext = $entry.title
                         }
                     }
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
+                        }
+                    }
 
                     if ($LibraryFolders -eq 'true') {
                         $LibraryName = $entry.'Library Name'
@@ -29842,6 +29989,17 @@ Elseif ($OtherMediaServerUrl -and $OtherMediaServerApiKey -and $UseOtherMediaSer
                     }
                     else {
                         $Titletext = $entry.title
+                    }
+                }
+                if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                    # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                    # which left Titletext blank above and broke the metadata search entirely.
+                    # Fall back to whichever of title/originalTitle actually has a value.
+                    if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                        $Titletext = $entry.title
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                        $Titletext = $entry.originalTitle
                     }
                 }
 
@@ -33697,6 +33855,8 @@ else {
     $Libraries = [System.Collections.Generic.List[object]]::new()
     Foreach ($Library in $Libsoverview) {
         if ($Library.Name -notin $LibstoExclude) {
+            Set-LibraryLanguageOverride -LibraryName $Library.Name
+
             $PlexHeaders = @{}
             if ($PlexToken) {
                 $PlexHeaders['X-Plex-Token'] = $PlexToken
@@ -34307,6 +34467,17 @@ else {
                         }
                         else {
                             $Titletext = $entry.title
+                        }
+                    }
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
                         }
                     }
 
@@ -35864,6 +36035,17 @@ else {
                     }
                     else {
                         $Titletext = $entry.title
+                    }
+                }
+                if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                    # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                    # which left Titletext blank above and broke the metadata search entirely.
+                    # Fall back to whichever of title/originalTitle actually has a value.
+                    if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                        $Titletext = $entry.title
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                        $Titletext = $entry.originalTitle
                     }
                 }
 

--- a/Posterizarr.ps1
+++ b/Posterizarr.ps1
@@ -2415,7 +2415,7 @@ function GetTMDBSeasonPoster {
                 }
             }
             Else {
-                Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+                Write-Entry -Subtext "No season posters found on TMDB for this season" -Path $global:configLogging -Color Yellow -log Warning
                 $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:SeasonNumber/images/posters"
             }
         }
@@ -2539,7 +2539,7 @@ function GetTMDBSeasonPoster {
                 }
             }
             Else {
-                Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+                Write-Entry -Subtext "No season posters found on TMDB for this season" -Path $global:configLogging -Color Yellow -log Warning
                 $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:SeasonNumber/images/posters"
             }
         }
@@ -2894,7 +2894,7 @@ function GetTMDBTitleCard {
             }
         }
         Else {
-            Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+            Write-Entry -Subtext "No title card images found on TMDB for this episode" -Path $global:configLogging -Color Yellow -log Warning
             $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:season_number/episode/$global:episodenumber/images/backdrops"
         }
     }
@@ -2961,7 +2961,7 @@ function GetTMDBTitleCard {
             }
         }
         Else {
-            Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+            Write-Entry -Subtext "No title card images found on TMDB for this episode" -Path $global:configLogging -Color Yellow -log Warning
             $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:season_number/episode/$global:episodenumber/images/backdrops"
         }
     }

--- a/config.example.json
+++ b/config.example.json
@@ -37,7 +37,12 @@
     "LogoLanguageOrder": [
       "en",
       "de"
-    ]
+    ],
+    "LibraryLanguageOverrides": {
+      "Beispiel-Bibliothek": {
+        "PreferredLanguageOrder": ["xx", "de", "en"]
+      }
+    }
   },
   "PlexPart": {
     "LibstoExclude": [


### PR DESCRIPTION
I run a Plex server with mostly English libraries plus a couple of German-language ones, and hit the wall that `PreferredLanguageOrder`/`PreferredSeasonLanguageOrder`/`PreferredBackgroundLanguageOrder`/`PreferredTCLanguageOrder`/`LogoLanguageOrder` are server-wide only. `LibstoExclude` can fully exclude a library but there was no way to just give one library a different language priority. This PR adds an optional `LibraryLanguageOverrides` section to config so you can do that per library, falling back to the server defaults for anything unspecified.

While testing this against a real library with non-Latin-script content, I found two more bugs worth fixing in the same pass:

**1. `Titletext` goes blank for natively non-Latin-script content.** The existing logic assumes any title matching the CJK/Cyrillic pattern needs to fall back to `originalTitle` — correct for foreign content displayed in that script, but for content that's natively in that script, Plex often has no distinct `originalTitle` set at all, so `Titletext` ends up completely empty and the metadata search silently breaks. Added a fallback to whichever of `title`/`originalTitle` actually has a value.

**2. Misleading "TMDB API response is null" for season posters/title cards.** Turns out this fires whenever `$response.posters`/`$response.stills` is an empty array — which in PowerShell is falsy, same as null. But TMDB returning `200` with `"posters": []` (a season genuinely has no dedicated art — common for smaller/regional shows) is not the same thing as the request actually failing, and the message had me chasing a language bug that didn't exist for a while. Only touched the 4 occurrences of this message that are actually paired with the empty-array check; left the other 9 alone since those are paired with a real null-response check and are already accurate.

All three tested against a live server with 387 real items across two libraries, full run through Normal Mode (not a synthetic test).

Example config addition:
```json
"LibraryLanguageOverrides": {
  "Beispiel-Bibliothek": {
    "PreferredLanguageOrder": ["xx", "de", "en"]
  }
}
```