### PR TITLE
Port two bugfixes from stable/PR #600 to the v3 rewrite

### DIFF
--- a/modules/functions/ApiHandlers.ps1
+++ b/modules/functions/ApiHandlers.ps1
@@ -1205,7 +1205,7 @@ function GetTMDBSeasonPoster {
                 }
             }
             Else {
-                Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+                Write-Entry -Subtext "No season posters found on TMDB for this season" -Path $global:configLogging -Color Yellow -log Warning
                 $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:SeasonNumber/images/posters"
             }
         }
@@ -1329,7 +1329,7 @@ function GetTMDBSeasonPoster {
                 }
             }
             Else {
-                Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+                Write-Entry -Subtext "No season posters found on TMDB for this season" -Path $global:configLogging -Color Yellow -log Warning
                 $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:SeasonNumber/images/posters"
             }
         }
@@ -1686,7 +1686,7 @@ function GetTMDBTitleCard {
             }
         }
         Else {
-            Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+            Write-Entry -Subtext "No title card images found on TMDB for this episode" -Path $global:configLogging -Color Yellow -log Warning
             $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:season_number/episode/$global:episodenumber/images/backdrops"
         }
     }
@@ -1753,7 +1753,7 @@ function GetTMDBTitleCard {
             }
         }
         Else {
-            Write-Entry -Subtext "TMDB API response is null" -Path $global:configLogging -Color Red -log Error
+            Write-Entry -Subtext "No title card images found on TMDB for this episode" -Path $global:configLogging -Color Yellow -log Warning
             $global:TMDBAssetChangeUrl = "https://www.themoviedb.org/tv/$($global:tmdbid)/season/$global:season_number/episode/$global:episodenumber/images/backdrops"
         }
     }

--- a/modules/functions/CoreGeneration.ps1
+++ b/modules/functions/CoreGeneration.ps1
@@ -42,6 +42,18 @@ function Invoke-MoviePosterCreation {
                         }
                     }
 
+                    if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                        # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                        # which left Titletext blank above and broke the metadata search entirely.
+                        # Fall back to whichever of title/originalTitle actually has a value.
+                        if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                            $Titletext = $entry.title
+                        }
+                        elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                            $Titletext = $entry.originalTitle
+                        }
+                    }
+
                     if ($LibraryFolders -eq 'true') {
                         $LibraryName = $entry.'Library Name'
                         if ($entry.extraFolder) {
@@ -1644,6 +1656,18 @@ function Invoke-ShowPosterCreation {
                     }
                     else {
                         $Titletext = $entry.title
+                    }
+                }
+
+                if ([string]::IsNullOrWhiteSpace($Titletext)) {
+                    # Native Cyrillic/CJK content often has no distinct originalTitle in Plex,
+                    # which left Titletext blank above and broke the metadata search entirely.
+                    # Fall back to whichever of title/originalTitle actually has a value.
+                    if (-not [string]::IsNullOrWhiteSpace($entry.title)) {
+                        $Titletext = $entry.title
+                    }
+                    elseif (-not [string]::IsNullOrWhiteSpace($entry.originalTitle)) {
+                        $Titletext = $entry.originalTitle
                     }
                 }
 


### PR DESCRIPTION
## What type of PR is this?
- [x] Bug Fix (non-breaking change which fixes an issue)

## Description

Follow-up to #600, which was closed because `main` is frozen while v3 is developed on `dev`. I checked both bugs against the new modular code after the split and confirmed they're still present, just relocated. Same fixes, applied to their new location.

**1. Blank `Titletext` for natively non-Latin-script content**
(`modules/functions/CoreGeneration.ps1`, both poster-creation functions)

The CJK/Cyrillic detection correctly falls back to `originalTitle` when foreign content is shown in translated/transliterated form. But for content that's natively in that script (e.g. a Russian show in a Russian-language library), Plex often has no distinct `originalTitle` at all — it's empty. That leaves `Titletext` blank and breaks the metadata search for the item entirely. Fix falls back to whichever of `title`/`originalTitle` actually has a value, only when the primary selection came out empty. This isn't Cyrillic-specific — it applies to any script the existing `$cjkPattern` regex matches (CJK, Cyrillic, Devanagari, Thai, Ethiopic, Georgian, Armenian, Bengali).

**2. Misleading "TMDB API response is null" for season posters/title cards**
(`modules/functions/ApiHandlers.ps1`)

4 of the 13 occurrences of this message are paired with an empty-array check (`if ($response.posters)` / `if ($response.stills)`), not a real null-response check. In PowerShell an empty array is falsy, so this message fires whenever TMDB simply has no dedicated season poster or title card for an item — a common, expected case for smaller/regional content — and misreports it as an API failure. Changed only those 4 to accurately say "none found," left the other 9 (paired with a genuine null check) unchanged since those are correct as-is.

## Have you updated the Documentation to reflect changes (if necessary)?
- [ ] Yes
- [x] No (bugfix only, no behavior/config surface change)

## Have you updated the CHANGELOG?
- [ ] Yes
- [x] No