### PR TITLE
Add per-library language override support

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -44,7 +44,15 @@
     "LogoLanguageOrder": [
       "en",
       "de"
-    ]
+    ],
+    "LibraryLanguageOverrides": {
+      "Beispiel-Bibliothek": {
+        "PreferredLanguageOrder": [
+          "de",
+          "en"
+        ]
+      }
+    }
   },
   "PlexPart": {
     "LibstoExclude": [

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -50,6 +50,14 @@
     - `PreferredTCLanguageOrder`: Specify language preferences for TCs. Default is `PleaseFillMe` ( It will take your poster lang order / `xx` is Textless). Example configurations can be found in the config file. 2-digit language codes can be found here: [ISO 3166-1 Lang Codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
         - If you set it to `xx` you tell the script it should only search for textless, posters with text will be skipped.
     - `LogoLanguageOrder`: Specify language preferences for Logos. Default is `en,de`. Example configurations can be found in the config file. 2-digit language codes can be found here: [ISO 3166-1 Lang Codes](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2).
+    - `LibraryLanguageOverrides`: Override the language order above on a per-library basis, for libraries where the server-wide setting doesn't fit (e.g. a single French or German library on an otherwise English server). Keyed by exact Plex library name; each entry sets one `PreferredLanguageOrder` that is applied uniformly to that library's posters, season posters and backgrounds. Title cards keep their own textless-first (`xx`) lead automatically unless the override itself already starts with `xx`, since TC language is about finding a base still image rather than the library's spoken language. Libraries not listed here are unaffected and keep using the server-wide settings.
+        ```json
+        "LibraryLanguageOverrides": {
+          "German Movies": {
+            "PreferredLanguageOrder": ["de", "en"]
+          }
+        }
+        ```
 
 
     #### PlexPart

--- a/modules/core/Variables.ps1
+++ b/modules/core/Variables.ps1
@@ -278,24 +278,21 @@ if ($global:PreferredBackgroundLanguageOrder -eq 'PleaseFillMe') {
 if ($global:PreferredTCLanguageOrder -eq 'PleaseFillMe') {
     $global:PreferredTCLanguageOrder = $global:PreferredLanguageOrder
 }
-# 2ï¸. Initialize all settings â€” function will validate and set defaults if needed
+# Initialize all settings, function will validate and set defaults if needed
 Initialize-LanguageSettings -SettingName "PreferredLanguageOrder"           -Label "Poster"
 Initialize-LanguageSettings -SettingName "PreferredSeasonLanguageOrder"     -Label "Season"
 Initialize-LanguageSettings -SettingName "PreferredTCLanguageOrder"         -Label "TC"
 Initialize-LanguageSettings -SettingName "PreferredBackgroundLanguageOrder" -Label "Background"
 
-# --- Library-specific language override support ---
+# Library-specific language override support
 $global:LibraryLanguageOverrides = $config.ApiPart.LibraryLanguageOverrides
 if (-not $global:LibraryLanguageOverrides) { $global:LibraryLanguageOverrides = @{} }
 
-# Stash the validated server-wide defaults so per-library overrides can fall back to them
 $global:DefaultPreferredLanguageOrder = $global:PreferredLanguageOrder
 $global:DefaultPreferredSeasonLanguageOrder = $global:PreferredSeasonLanguageOrder
 $global:DefaultPreferredTCLanguageOrder = $global:PreferredTCLanguageOrder
 $global:DefaultPreferredBackgroundLanguageOrder = $global:PreferredBackgroundLanguageOrder
 $global:DefaultLogoLanguageOrder = $global:LogoLanguageOrder
-
-# --- end library-specific language override support ---
 
 # default to TMDB if favprovider missing
 if (!$global:FavProvider) {

--- a/modules/core/Variables.ps1
+++ b/modules/core/Variables.ps1
@@ -284,6 +284,19 @@ Initialize-LanguageSettings -SettingName "PreferredSeasonLanguageOrder"     -Lab
 Initialize-LanguageSettings -SettingName "PreferredTCLanguageOrder"         -Label "TC"
 Initialize-LanguageSettings -SettingName "PreferredBackgroundLanguageOrder" -Label "Background"
 
+# --- Library-specific language override support ---
+$global:LibraryLanguageOverrides = $config.ApiPart.LibraryLanguageOverrides
+if (-not $global:LibraryLanguageOverrides) { $global:LibraryLanguageOverrides = @{} }
+
+# Stash the validated server-wide defaults so per-library overrides can fall back to them
+$global:DefaultPreferredLanguageOrder = $global:PreferredLanguageOrder
+$global:DefaultPreferredSeasonLanguageOrder = $global:PreferredSeasonLanguageOrder
+$global:DefaultPreferredTCLanguageOrder = $global:PreferredTCLanguageOrder
+$global:DefaultPreferredBackgroundLanguageOrder = $global:PreferredBackgroundLanguageOrder
+$global:DefaultLogoLanguageOrder = $global:LogoLanguageOrder
+
+# --- end library-specific language override support ---
+
 # default to TMDB if favprovider missing
 if (!$global:FavProvider) {
     Write-Entry -Message "FavProvider not set in config, setting it to 'TMDB' for you" -Path $global:configLogging -Color Yellow -log Warning

--- a/modules/functions/CoreGeneration.ps1
+++ b/modules/functions/CoreGeneration.ps1
@@ -2,6 +2,7 @@ function Invoke-MoviePosterCreation {
     param (
         $entry
     )
+        Set-LibraryLanguageOverride -LibraryName $entry.'Library Name'
         try {
             if ($($entry.RootFoldername)) {
                 # check if item has skip label
@@ -1594,6 +1595,7 @@ function Invoke-ShowPosterCreation {
     param (
         $entry
     )
+        Set-LibraryLanguageOverride -LibraryName $entry.'Library Name'
 
         if ($($entry.RootFoldername)) {
             # check if item has skip label
@@ -4154,6 +4156,7 @@ function Invoke-TitleCardCreation {
     param (
         $episode
     )
+        Set-LibraryLanguageOverride -LibraryName $episode.'Library Name'
 
     try {
         $SkippingText = 'false'

--- a/modules/functions/CoreGeneration.ps1
+++ b/modules/functions/CoreGeneration.ps1
@@ -2,6 +2,7 @@ function Invoke-MoviePosterCreation {
     param (
         $entry
     )
+        if ($null -eq $entry) { return }
         Set-LibraryLanguageOverride -LibraryName $entry.'Library Name'
         try {
             if ($($entry.RootFoldername)) {
@@ -1595,6 +1596,7 @@ function Invoke-ShowPosterCreation {
     param (
         $entry
     )
+        if ($null -eq $entry) { return }
         Set-LibraryLanguageOverride -LibraryName $entry.'Library Name'
 
         if ($($entry.RootFoldername)) {
@@ -4151,11 +4153,11 @@ function Invoke-ShowPosterCreation {
         }
 
 }
-
 function Invoke-TitleCardCreation {
     param (
         $episode
     )
+        if ($null -eq $episode) { return }
         Set-LibraryLanguageOverride -LibraryName $episode.'Library Name'
 
     try {

--- a/modules/functions/System.ps1
+++ b/modules/functions/System.ps1
@@ -605,6 +605,52 @@ function Initialize-LanguageSettings {
 
 }
 
+function Set-LibraryLanguageOverride {
+    # A library override sets one language order (PreferredLanguageOrder) that
+    # applies to every asset type for that library - a "this library is
+    # German/French/etc" switch, not four settings to keep in sync. Season and
+    # Background inherit it directly; TC keeps its textless-first ("xx") lead
+    # unless the override already starts with one, since TC language is about
+    # base-image search, not the library's spoken language.
+    param([string]$LibraryName)
+
+    # $global:LibraryLanguageOverrides is a PSCustomObject when read fresh from
+    # config.json, but crossing into a -Parallel runspace via $using: deserializes
+    # it as a Hashtable instead - handle both shapes rather than assuming one.
+    $override = $null
+    if ($global:LibraryLanguageOverrides -is [System.Collections.IDictionary]) {
+        if ($global:LibraryLanguageOverrides.Contains($LibraryName)) {
+            $override = $global:LibraryLanguageOverrides[$LibraryName]
+        }
+    }
+    elseif ($global:LibraryLanguageOverrides -and ($global:LibraryLanguageOverrides.PSObject.Properties.Name -contains $LibraryName)) {
+        $override = $global:LibraryLanguageOverrides.$LibraryName
+    }
+
+    if (-not $override) {
+        Set-Variable -Name "PreferredLanguageOrder" -Scope Global -Value $global:DefaultPreferredLanguageOrder
+        Set-Variable -Name "PreferredSeasonLanguageOrder" -Scope Global -Value $global:DefaultPreferredSeasonLanguageOrder
+        Set-Variable -Name "PreferredTCLanguageOrder" -Scope Global -Value $global:DefaultPreferredTCLanguageOrder
+        Set-Variable -Name "PreferredBackgroundLanguageOrder" -Scope Global -Value $global:DefaultPreferredBackgroundLanguageOrder
+        Set-Variable -Name "LogoLanguageOrder" -Scope Global -Value $global:DefaultLogoLanguageOrder
+    }
+    else {
+        $order = if ($override.PreferredLanguageOrder) { $override.PreferredLanguageOrder } else { $global:DefaultPreferredLanguageOrder }
+        $tcOrder = if ($order -and $order[0] -eq 'xx') { $order } else { @('xx') + $order }
+
+        Set-Variable -Name "PreferredLanguageOrder" -Scope Global -Value $order
+        Set-Variable -Name "PreferredSeasonLanguageOrder" -Scope Global -Value $order
+        Set-Variable -Name "PreferredTCLanguageOrder" -Scope Global -Value $tcOrder
+        Set-Variable -Name "PreferredBackgroundLanguageOrder" -Scope Global -Value $order
+        Set-Variable -Name "LogoLanguageOrder" -Scope Global -Value $order
+    }
+
+    Initialize-LanguageSettings -SettingName "PreferredLanguageOrder"           -Label "Poster"
+    Initialize-LanguageSettings -SettingName "PreferredSeasonLanguageOrder"     -Label "Season"
+    Initialize-LanguageSettings -SettingName "PreferredTCLanguageOrder"         -Label "TC"
+    Initialize-LanguageSettings -SettingName "PreferredBackgroundLanguageOrder" -Label "Background"
+}
+
 function Test-PathPermissions {
     param (
         [string]$PathToTest

--- a/webui/backend/config_mapper.py
+++ b/webui/backend/config_mapper.py
@@ -281,6 +281,7 @@ CONFIG_GROUPS = {
     "EmbyAPIKey": "ApiPart",
     "PreferredBackgroundLanguageOrder": "ApiPart",
     "PreferredTCLanguageOrder": "ApiPart",
+    "LibraryLanguageOverrides": "ApiPart",
     # PlexPart
     "PlexLibstoExclude": "PlexPart",
     "PlexUrl": "PlexPart",
@@ -597,6 +598,7 @@ UI_GROUPS = {
         "PreferredBackgroundLanguageOrder",
         "PreferredTCLanguageOrder",
         "LogoLanguageOrder",
+        "LibraryLanguageOverrides",
         "SendNotification",
         "Discord",
         "AppriseUrl",
@@ -1017,6 +1019,7 @@ DISPLAY_NAMES = {
     "PreferredBackgroundLanguageOrder": "Background Language Order",
     "PreferredTCLanguageOrder": "TitleCard Language Order",
     "LogoLanguageOrder": "Logo Language Order",
+    "LibraryLanguageOverrides": "Per-Library Language Overrides",
     # Image Filters
     "WidthHeightFilter": "Width/Height Filter",
     "PosterMinWidth": "Poster Min Width",

--- a/webui/frontend/src/components/ConfigEditor.jsx
+++ b/webui/frontend/src/components/ConfigEditor.jsx
@@ -943,6 +943,77 @@ const SettingCard = ({ settingKey, groupName, config, usingFlatStructure, webuiL
                 </div>
             );
         }
+        if (settingKey === "LibraryLanguageOverrides") {
+            // One language order per library, applied to posters/seasons/backgrounds
+            // for that library (title cards keep their own textless-first lead).
+            // A single field per library instead of one per asset type, since the
+            // real intent is "this library is German/French/etc", not four
+            // settings to keep in sync.
+            const dictValue = value && typeof value === 'object' ? value : {};
+            const getOrder = (v) => Array.isArray(v?.PreferredLanguageOrder) ? v.PreferredLanguageOrder.join(',') : '';
+
+            const handleUpdatePair = (oldKey, newKey, orderText) => {
+                const newDict = { ...dictValue };
+                if (oldKey !== newKey) {
+                    delete newDict[oldKey];
+                }
+                const order = orderText.split(',').map((s) => s.trim()).filter(Boolean);
+                newDict[newKey] = { ...(dictValue[oldKey] || {}), PreferredLanguageOrder: order };
+                updateValue(fieldKey, newDict);
+            };
+
+            const handleRemovePair = (keyToRemove) => {
+                const newDict = { ...dictValue };
+                delete newDict[keyToRemove];
+                updateValue(fieldKey, newDict);
+            };
+
+            const handleAddPair = () => {
+                const newDict = { ...dictValue, "Library Name": { PreferredLanguageOrder: ["en"] } };
+                updateValue(fieldKey, newDict);
+            };
+
+            return (
+                <div className="space-y-2">
+                    {Object.entries(dictValue).map(([k, v], idx) => (
+                        <div key={idx} className="flex gap-2 items-start">
+                            <input
+                                className={`${commonInputClass} font-mono text-xs`}
+                                value={k}
+                                placeholder="Library Name"
+                                onChange={(e) => handleUpdatePair(k, e.target.value, getOrder(v))}
+                                disabled={disabled}
+                            />
+                            <ArrowRight className="w-8 h-8 text-theme-muted mt-1 flex-shrink-0" />
+                            <input
+                                className={`${commonInputClass} font-mono text-xs`}
+                                value={getOrder(v)}
+                                placeholder="e.g. de,en"
+                                onChange={(e) => handleUpdatePair(k, k, e.target.value)}
+                                disabled={disabled}
+                            />
+                            <button
+                                onClick={() => handleRemovePair(k)}
+                                className="p-2.5 bg-red-500/10 text-red-500 rounded-lg hover:bg-red-500/20"
+                                disabled={disabled}
+                            >
+                                <Trash2 className="w-4 h-4" />
+                            </button>
+                        </div>
+                    ))}
+                    <button
+                        onClick={handleAddPair}
+                        className="w-full py-2 border-2 border-dashed border-theme rounded-lg text-theme-muted hover:text-theme-primary hover:border-theme-primary transition-all flex items-center justify-center gap-2 text-sm"
+                        disabled={disabled}
+                    >
+                        <Plus className="w-4 h-4" /> Add Library Override
+                    </button>
+                    <p className="text-[10px] text-theme-muted italic">
+                        Language order for this library, comma-separated (e.g. de,en). Applies to posters, seasons and backgrounds for this library; title cards keep their textless-first preference automatically.
+                    </p>
+                </div>
+            );
+        }
         if (settingKey === "NewLineWords") {
             const dictValue = value && typeof value === 'object' ? value : {};
 

--- a/webui/frontend/src/components/ConfigEditor.jsx
+++ b/webui/frontend/src/components/ConfigEditor.jsx
@@ -950,15 +950,19 @@ const SettingCard = ({ settingKey, groupName, config, usingFlatStructure, webuiL
             // real intent is "this library is German/French/etc", not four
             // settings to keep in sync.
             const dictValue = value && typeof value === 'object' ? value : {};
-            const getOrder = (v) => Array.isArray(v?.PreferredLanguageOrder) ? v.PreferredLanguageOrder.join(',') : '';
 
-            const handleUpdatePair = (oldKey, newKey, orderText) => {
+            const handleUpdateKey = (oldKey, newKey) => {
                 const newDict = { ...dictValue };
                 if (oldKey !== newKey) {
                     delete newDict[oldKey];
                 }
-                const order = orderText.split(',').map((s) => s.trim()).filter(Boolean);
-                newDict[newKey] = { ...(dictValue[oldKey] || {}), PreferredLanguageOrder: order };
+                newDict[newKey] = dictValue[oldKey] || { PreferredLanguageOrder: [] };
+                updateValue(fieldKey, newDict);
+            };
+
+            const handleUpdateOrder = (key, newOrder) => {
+                const newDict = { ...dictValue };
+                newDict[key] = { ...(dictValue[key] || {}), PreferredLanguageOrder: newOrder };
                 updateValue(fieldKey, newDict);
             };
 
@@ -974,43 +978,51 @@ const SettingCard = ({ settingKey, groupName, config, usingFlatStructure, webuiL
             };
 
             return (
-                <div className="space-y-2">
+                <div className="space-y-4">
                     {Object.entries(dictValue).map(([k, v], idx) => (
-                        <div key={idx} className="flex gap-2 items-start">
-                            <input
-                                className={`${commonInputClass} font-mono text-xs`}
-                                value={k}
-                                placeholder="Library Name"
-                                onChange={(e) => handleUpdatePair(k, e.target.value, getOrder(v))}
-                                disabled={disabled}
-                            />
-                            <ArrowRight className="w-8 h-8 text-theme-muted mt-1 flex-shrink-0" />
-                            <input
-                                className={`${commonInputClass} font-mono text-xs`}
-                                value={getOrder(v)}
-                                placeholder="e.g. de,en"
-                                onChange={(e) => handleUpdatePair(k, k, e.target.value)}
-                                disabled={disabled}
-                            />
-                            <button
-                                onClick={() => handleRemovePair(k)}
-                                className="p-2.5 bg-red-500/10 text-red-500 rounded-lg hover:bg-red-500/20"
-                                disabled={disabled}
-                            >
-                                <Trash2 className="w-4 h-4" />
-                            </button>
+                        <div key={idx} className="flex flex-col gap-3 p-4 bg-theme-bg/30 border border-theme rounded-lg relative group transition-all">
+                            <div className="flex items-center gap-3">
+                                <div className="flex-1">
+                                    <label className="block text-xs font-medium text-theme-muted mb-1">Library Name</label>
+                                    <input
+                                        className={`${commonInputClass} font-mono text-sm`}
+                                        value={k}
+                                        placeholder="Library Name"
+                                        onChange={(e) => handleUpdateKey(k, e.target.value)}
+                                        disabled={disabled}
+                                    />
+                                </div>
+                                <button
+                                    onClick={() => handleRemovePair(k)}
+                                    className="p-2.5 mt-5 bg-red-500/10 text-red-500 rounded-lg hover:bg-red-500/20 flex-shrink-0 transition-colors"
+                                    disabled={disabled}
+                                    title="Remove Library Override"
+                                >
+                                    <Trash2 className="w-5 h-5" />
+                                </button>
+                            </div>
+                            
+                            <div className="pt-3 border-t border-theme/50">
+                                <LanguageOrderSelector
+                                    value={v?.PreferredLanguageOrder || []}
+                                    onChange={(newOrder) => handleUpdateOrder(k, newOrder)}
+                                    helpText="Applies to posters, seasons and backgrounds for this library; title cards keep their textless-first preference automatically."
+                                />
+                            </div>
                         </div>
                     ))}
                     <button
                         onClick={handleAddPair}
-                        className="w-full py-2 border-2 border-dashed border-theme rounded-lg text-theme-muted hover:text-theme-primary hover:border-theme-primary transition-all flex items-center justify-center gap-2 text-sm"
+                        className="w-full py-3 border-2 border-dashed border-theme rounded-lg text-theme-muted hover:text-theme-primary hover:border-theme-primary transition-all flex items-center justify-center gap-2 text-sm font-medium"
                         disabled={disabled}
                     >
-                        <Plus className="w-4 h-4" /> Add Library Override
+                        <Plus className="w-5 h-5" /> Add Library Override
                     </button>
-                    <p className="text-[10px] text-theme-muted italic">
-                        Language order for this library, comma-separated (e.g. de,en). Applies to posters, seasons and backgrounds for this library; title cards keep their textless-first preference automatically.
-                    </p>
+                    {Object.keys(dictValue).length === 0 && (
+                        <p className="text-[10px] text-theme-muted italic">
+                            Language order for specific libraries. Applies to posters, seasons and backgrounds for this library; title cards keep their textless-first preference automatically.
+                        </p>
+                    )}
                 </div>
             );
         }


### PR DESCRIPTION
## What type of PR is this?
- [x] Feature/Tweak (non-breaking change which adds new functionality)

## Description

Adds support for overriding the server-wide language preference on a per-library basis - e.g. a German or French library that should get its own language's posters/backgrounds instead of the server default, without changing the server-wide setting for every other library.

**Design**: one language order per library override (`LibraryLanguageOverrides` in `ApiPart`), applied uniformly to posters/seasons/backgrounds for that library. Title cards keep their own textless-first ("xx") lead automatically unless the override already starts with one - TC language is about finding a base still image, not the library's spoken language, so it stays a separate concern. I initially built this as four independent per-asset-type settings mirroring the existing server-wide ones, then simplified to one field per library after testing showed the four-field version invites exactly the kind of partial-override bug (poster overridden, season silently not) that a library override is supposed to prevent.

**Where it hooks in**: at the top of the three top-level per-item entry points (`Invoke-MoviePosterCreation`, `Invoke-ShowPosterCreation`, `Invoke-TitleCardCreation`), so it re-applies correctly per item inside `-Parallel` workers rather than once at library-gather time (which would leave whichever library gathered last "stuck" as the active override for everything processed afterward, regardless of that item's actual library).

**Three real bugs found and fixed during testing** (documenting honestly since none were obvious from reading the code):
1. Applying the override once during the library-gather loop, not per-item - works fine in principle, breaks under `-Parallel` since gathering finishes for all libraries before any item processing starts.
2. `LibraryLanguageOverrides` crosses a `-Parallel` runspace boundary via `$using:` and gets silently deserialized as a `Hashtable` instead of the original `PSCustomObject` - the two need different property-access patterns, and only handling one silently no-ops on the other.
3. The config-migration logic in `System.ps1` treats any `ApiPart` key not present in the upstream `config.example.json` as obsolete and strips it on every startup - so the setting needs to ship in both files together or it silently deletes itself.

Tested end-to-end against real Plex/TMDB data with `-Parallel` active: overridden libraries correctly get their configured language, non-overridden libraries are unaffected, and the setting survives repeated Posterizarr runs without being stripped.

**WebUI**: registered in `config_mapper.py` so the setting round-trips through save/load safely even before a full editor existed, plus a lightweight editor in `ConfigEditor.jsx` (library name -> comma-separated language order) following the existing dynamic-pair pattern already used for `NewLineWords`.

## Have you updated the Documentation to reflect changes (if necessary)?
- [ ] Yes
- [x] No (happy to add a docs page if useful - wanted to get the behavior right first)

## Have you updated the CHANGELOG?
- [ ] Yes
- [x] No