### PR TITLE
fix: add timeout to image-download HTTP calls to prevent indefinite hangs

### DIFF
--- a/modules/functions/ApiHandlers.ps1
+++ b/modules/functions/ApiHandlers.ps1
@@ -3012,7 +3012,13 @@ function GetTVDBTitleCard {
 }
 
 function GetIMDBPoster {
-    $response = Invoke-WebRequest -Uri "https://www.imdb.com/title/$($global:imdbid)/mediaviewer" -Method GET
+    try {
+        $response = Invoke-WebRequest -Uri "https://www.imdb.com/title/$($global:imdbid)/mediaviewer" -Method GET -TimeoutSec 20 -ErrorAction Stop
+    }
+    catch {
+        Write-Entry -Subtext "IMDB request timed out or failed: $($_.Exception.Message)" -Path $global:configLogging -Color Yellow -log Warning
+        return
+    }
     $global:posterurl = $response.images.src[1]
     if (!$global:posterurl) {
         Write-Entry -Subtext "No show match or poster found on IMDB" -Path $global:configLogging -Color Yellow -log Warning
@@ -3228,7 +3234,7 @@ function UploadOtherMediaServerArtwork {
                 $tempFile = Join-Path -Path $global:ScriptRoot -ChildPath "temp\hashcompare.jpg"
 
                 # Try to download the image
-                $response = Invoke-WebRequest -Uri $ImageUrl -OutFile $tempFile -ErrorAction Stop
+                $response = Invoke-WebRequest -Uri $ImageUrl -OutFile $tempFile -TimeoutSec 30 -ErrorAction Stop
 
                 $magickcommand = "& `"$magick`" identify -verbose `"$tempFile`""
                 $magickcommand | Write-MagickLog
@@ -3992,7 +3998,7 @@ function MassDownloadPlexArtwork {
                             try {
                                 Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                                 Write-Entry -Subtext "Downloading Poster from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -ErrorAction Stop
+                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -TimeoutSec 30 -ErrorAction Stop
                             }
                             catch {
                                 if ($_.Exception.Response) {
@@ -4116,7 +4122,7 @@ function MassDownloadPlexArtwork {
                             try {
                                 Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                                 Write-Entry -Subtext "Downloading Poster from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -ErrorAction Stop
+                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -TimeoutSec 30 -ErrorAction Stop
                             }
                             catch {
                                 if ($_.Exception.Response) {
@@ -4305,7 +4311,7 @@ function MassDownloadPlexArtwork {
                         try {
                             Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                             Write-Entry -Subtext "Downloading Poster from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -ErrorAction Stop
+                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -TimeoutSec 30 -ErrorAction Stop
                         }
                         catch {
                             if ($_.Exception.Response) {
@@ -4431,7 +4437,7 @@ function MassDownloadPlexArtwork {
                         try {
                             Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                             Write-Entry -Subtext "Downloading Poster from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -ErrorAction Stop
+                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -TimeoutSec 30 -ErrorAction Stop
                         }
                         catch {
                             if ($_.Exception.Response) {
@@ -4576,7 +4582,7 @@ function MassDownloadPlexArtwork {
                             try {
                                 Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                                 Write-Entry -Subtext "Downloading Poster from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -ErrorAction Stop
+                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -TimeoutSec 30 -ErrorAction Stop
                             }
                             catch {
                                 if ($_.Exception.Response) {
@@ -4735,7 +4741,7 @@ function MassDownloadPlexArtwork {
                                     try {
                                         Write-Entry -Subtext "Poster url: $(RedactMediaServerUrl -url $global:posterurl)" -Path $global:configLogging -Color White -log Info
                                         Write-Entry -Subtext "Downloading Titlecard from 'Plex'" -Path $global:configLogging -Color DarkMagenta -log Info
-                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                     }
                                     catch {
                                         if ($_.Exception.Response) {

--- a/modules/functions/CoreGeneration.ps1
+++ b/modules/functions/CoreGeneration.ps1
@@ -310,7 +310,7 @@ function Invoke-MoviePosterCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded) {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -TimeoutSec 30 -ErrorAction Stop
                                         }
                                     }
                                     catch {
@@ -488,7 +488,7 @@ function Invoke-MoviePosterCreation {
                                                     if ([string]::IsNullOrWhiteSpace($urlExtension)) { $urlExtension = ".png" }
                                                                                                                     $LogoImage = Join-Path $TempPath ("$($entry.RootFoldername)_logo" + $urlExtension); Write-Entry -Message "Logo Used: $global:LogoUrl" -Path $global:configLogging -Color Cyan -log Debug
                                                     try {
-                                                        $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -ErrorAction Stop
+                                                        $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -TimeoutSec 30 -ErrorAction Stop
                                                     }
                                                     catch {
                                                         if ($_.Exception.Response) {
@@ -1042,7 +1042,7 @@ function Invoke-MoviePosterCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded) {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -TimeoutSec 30 -ErrorAction Stop
                                         }
                                     }
                                     catch {
@@ -1220,7 +1220,7 @@ function Invoke-MoviePosterCreation {
                                                     if ([string]::IsNullOrWhiteSpace($urlExtension)) { $urlExtension = ".png" }
                                                                                                                     $LogoImage = Join-Path $TempPath ("$($entry.RootFoldername)_logo" + $urlExtension); Write-Entry -Message "Logo Used: $global:LogoUrl" -Path $global:configLogging -Color Cyan -log Debug
                                                     try {
-                                                        $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -ErrorAction Stop
+                                                        $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -TimeoutSec 30 -ErrorAction Stop
                                                     }
                                                     catch {
                                                         if ($_.Exception.Response) {
@@ -1892,7 +1892,7 @@ function Invoke-ShowPosterCreation {
                             Else {
                                 try {
                                     if (!$global:PlexartworkDownloaded) {
-                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -ErrorAction Stop
+                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $PosterImage -TimeoutSec 30 -ErrorAction Stop
                                     }
                                 }
                                 catch {
@@ -2070,7 +2070,7 @@ function Invoke-ShowPosterCreation {
                                                 if ([string]::IsNullOrWhiteSpace($urlExtension)) { $urlExtension = ".png" }
                                                                                                                 $LogoImage = Join-Path $TempPath ("$($entry.RootFoldername)_logo" + $urlExtension); Write-Entry -Message "Logo Used: $global:LogoUrl" -Path $global:configLogging -Color Cyan -log Debug
                                                 try {
-                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -ErrorAction Stop
+                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -TimeoutSec 30 -ErrorAction Stop
                                                 }
                                                 catch {
                                                     if ($_.Exception.Response) {
@@ -2638,7 +2638,7 @@ function Invoke-ShowPosterCreation {
                             Else {
                                 try {
                                     if (!$global:PlexartworkDownloaded) {
-                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -ErrorAction Stop
+                                        $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $BackgroundImage -TimeoutSec 30 -ErrorAction Stop
                                     }
                                 }
                                 catch {
@@ -2816,7 +2816,7 @@ function Invoke-ShowPosterCreation {
                                                 if ([string]::IsNullOrWhiteSpace($urlExtension)) { $urlExtension = ".png" }
                                                                                                                 $LogoImage = Join-Path $TempPath ("$($entry.RootFoldername)_logo" + $urlExtension); Write-Entry -Message "Logo Used: $global:LogoUrl" -Path $global:configLogging -Color Cyan -log Debug
                                                 try {
-                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -ErrorAction Stop
+                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -TimeoutSec 30 -ErrorAction Stop
                                                 }
                                                 catch {
                                                     if ($_.Exception.Response) {
@@ -3559,7 +3559,7 @@ function Invoke-ShowPosterCreation {
                                     Else {
                                         try {
                                             if (!$global:PlexartworkDownloaded) {
-                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -ErrorAction Stop
+                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -TimeoutSec 30 -ErrorAction Stop
                                             }
                                         }
                                         catch {
@@ -3798,7 +3798,7 @@ function Invoke-ShowPosterCreation {
                                                                                                                                 $LogoImage = Join-Path $TempPath ("$($entry.RootFoldername)_logo" + $urlExtension); Write-Entry -Message "Logo Used: $global:LogoUrl" -Path $global:configLogging -Color Cyan -log Debug
 
                                                                 try {
-                                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -ErrorAction Stop
+                                                                    $response = Invoke-WebRequest -Uri $global:LogoUrl -OutFile $LogoImage -TimeoutSec 30 -ErrorAction Stop
                                                                 }
                                                                 catch {
                                                                     if ($_.Exception.Response) {
@@ -3894,7 +3894,7 @@ function Invoke-ShowPosterCreation {
                                     Else {
                                         try {
                                             if (!$global:PlexartworkDownloaded) {
-                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -ErrorAction Stop
+                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $SeasonImage -TimeoutSec 30 -ErrorAction Stop
                                             }
                                         }
                                         catch {
@@ -4516,7 +4516,7 @@ function Invoke-TitleCardCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded -and $global:TempImagecopied -ne 'true') {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                             Copy-Item -LiteralPath $EpisodeImage -destination $EpisodeTempImage | Out-Null
                                         }
                                     }
@@ -4731,7 +4731,7 @@ function Invoke-TitleCardCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded) {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                         }
                                     }
                                     catch {
@@ -5282,7 +5282,7 @@ function Invoke-TitleCardCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded) {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                         }
                                     }
                                     catch {
@@ -5481,7 +5481,7 @@ function Invoke-TitleCardCreation {
                                 Else {
                                     try {
                                         if (!$global:PlexartworkDownloaded) {
-                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                            $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                         }
                                     }
                                     catch {
@@ -6028,7 +6028,7 @@ function Invoke-TitleCardCreation {
                                                     Else {
                                                         try {
                                                             if (!$global:PlexartworkDownloaded) {
-                                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                                             }
                                                         }
                                                         catch {
@@ -6227,7 +6227,7 @@ function Invoke-TitleCardCreation {
                                                     Else {
                                                         try {
                                                             if (!$global:PlexartworkDownloaded) {
-                                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -ErrorAction Stop
+                                                                $response = Invoke-WebRequest -Uri $global:posterurl -OutFile $EpisodeImage -TimeoutSec 30 -ErrorAction Stop
                                                             }
                                                         }
                                                         catch {


### PR DESCRIPTION
## What's the issue

Every `Invoke-WebRequest` that downloads artwork - poster, background, logo, season, episode, across TMDB/TVDB/Fanart/Plex/IMDB - runs with no `-TimeoutSec`, and in most cases no surrounding `try/catch` either. If a provider's connection stalls mid-request, the call blocks forever and the whole script hangs: no error, no log line, nothing. Only way out is killing the process.

Ran into this running a full library regeneration overnight (~49k images across 6 libraries). The run hung four separate times, always mid-episode, with the log going completely silent and zero CPU activity for 10+ minutes each time. First guess was a `ParallelJobs` concurrency problem, so I tried lowering it (5 → 4 → 2) between restarts - it hung at all three values. Once I actually read the code path it stalled on, the real pattern was clear: every hang was a single stalled HTTP connection to an image host, not thread contention.

`GetIMDBPoster` was the worst offender - no timeout *and* no try/catch at all, so a stalled IMDB scrape request couldn't even be caught gracefully.

## The fix

- Added `-TimeoutSec 30` to all 24 image-download `Invoke-WebRequest -OutFile ...` calls across `CoreGeneration.ps1` and `ApiHandlers.ps1` (poster/background/logo/season/episode, all providers).
- Wrapped `GetIMDBPoster`'s request in `try/catch` with the new timeout, so a stall now logs a warning and degrades to "no IMDB poster found" instead of hanging the run.

Verified: patched files parse cleanly (`[System.Management.Automation.Language.Parser]::ParseFile`), and the fix has been running in production overnight since - the exact hang pattern that hit 4 times before the fix hasn't recurred once since, across a subsequent full clean run of the same library.

No config changes needed, no behavior change for the happy path - this only changes what happens when a provider connection stalls, which previously had no bound at all.