### PR TITLE
fix: group sync season export by ParentIndexNumber, not SeasonName

### DIFF
--- a/modules/modes/SyncMode.ps1
+++ b/modules/modes/SyncMode.ps1
@@ -716,7 +716,12 @@
         if ($OtherEpisodesBySeriesId.ContainsKey($showIdKey)) {
             $seriesEpisodes = $OtherEpisodesBySeriesId[$showIdKey]
         }
-        $seasons = $seriesEpisodes | Group-Object -Property SeasonName | Sort-Object -Property Name
+        # Group by ParentIndexNumber, not SeasonName. The season and title card lookups
+        # further down match rows on "Season Number", which comes from ParentIndexNumber,
+        # and folder-derived season names do not always agree with it. Grouping by name
+        # then emits several rows carrying the same season number while other season
+        # numbers get no row at all, so those seasons cannot match.
+        $seasons = $seriesEpisodes | Group-Object -Property ParentIndexNumber | Sort-Object -Property { $_.Name -as [int] }
         foreach ($Season in $Seasons) {
             # Sort episodes within the season by IndexNumber
             $SeasonEpisodes = $Season.Group | Sort-Object -Property indexnumber
@@ -767,7 +772,7 @@
                 "tmdbid"                       = $show.tmdbid
                 "type"                         = "Episode"
                 "Season Number"                = $SeasonEpisodes[0].ParentIndexNumber
-                "SeasonName"                   = $Season.Name
+                "SeasonName"                   = $SeasonEpisodes[0].SeasonName
                 "Episodes"                     = $Episodes
                 "Title"                        = $EpisodeTitles
                 "OtherMediaServerTitleCardTag" = $Thumbs


### PR DESCRIPTION
## Description

`SyncMode.ps1` L.719 grouped the destination episode export by `SeasonName` but labelled each row with `$SeasonEpisodes[0].ParentIndexNumber`, and the season poster and title card lookups (L.1153, L.1245) match rows on that label. When the two fields disagree, the export carries several rows with the same season number and none for others, so those seasons can never match.

Now grouped by `ParentIndexNumber`, the field the lookups actually use. Two small consequences handled in the same change:

- The `SeasonName` CSV column keeps a real season name (taken from the row's first episode) instead of becoming the stringified group key.
- The sort is numeric (`$_.Name -as [int]`) rather than lexicographic; `-as` returns null instead of throwing for episodes without a `ParentIndexNumber`, which group into a row whose `Season Number` is empty and fall through the existing match logic exactly as before.

Measured on my library (Plex source, Jellyfin 10.11.11 destination): One Piece (1,081 episodes, arc-named season folders) previously exported three rows all labelled season 13 and no rows for seasons 16, 19 and 20, producing 331 `Could not match episode ...` errors per syncjelly run. With this change its export matches the source's season split 1:1 (all 21 seasons plus Specials, identical episode counts and ranges). Shows whose season names already agree with their index produce identical rows apart from ordering, verified on the same library.

## Related Issue(s)

Fixes #641

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to break)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactor or cleanup

## Developer Checklist
- [ ] Is the versioning adapted in the script?
- [ ] Is the versioning adapted in `Release.txt`?
- [x] I have verified that no images or unnecessary binary files were uploaded to the repository.
- [x] My code follows the existing style and structure of the project.

Version files left untouched, same as #640.
