### PR TITLE
Fix incomplete Jellyfin 12 imports caused by BoxSet collapsing

### DIFF
--- a/modules/modes/EmbyJellyMode.ps1
+++ b/modules/modes/EmbyJellyMode.ps1
@@ -115,14 +115,14 @@
         if ($slib.Name -notin $LibstoExclude) {
             if ($slib.CollectionType -eq 'movies') {
                 Write-Entry -Subtext "Getting all Itmes from [$($slib.Name)] with item id [$($slib.ItemId)]" -Path $global:configLogging -Color Cyan -log Debug
-                $allMoviesquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,OriginalTitle,Settings,Path,Overview,ProductionYear,Tags,Width,Height,MediaStreams&IncludeItemTypes=Movie"
+                $allMoviesquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,OriginalTitle,Settings,Path,Overview,ProductionYear,Tags,Width,Height,MediaStreams&IncludeItemTypes=Movie&CollapseBoxSetItems=false"
                 $Querytemp = Invoke-RestMethod -Method Get -Uri $allMoviesquery -Headers $global:OtherMediaServerHeaders
                 $AllMovies.Add($Querytemp)
             }
             if ($slib.CollectionType -eq 'tvshows') {
                 Write-Entry -Subtext "Getting all Itmes from [$($slib.Name)] with item id [$($slib.ItemId)]" -Path $global:configLogging -Color Cyan -log Debug
-                $allShowsquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,SeasonUserData,OriginalTitle,Path,Overview,ProductionYear,Tags,Width,Height,MediaStreams&IncludeItemTypes=Series"
-                $allEpisodesquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,SeasonUserData,OriginalTitle,Path,Overview,Settings,Tags,Width,Height,MediaStreams&IncludeItemTypes=Episode"
+                $allShowsquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,SeasonUserData,OriginalTitle,Path,Overview,ProductionYear,Tags,Width,Height,MediaStreams&IncludeItemTypes=Series&CollapseBoxSetItems=false"
+                $allEpisodesquery = "$OtherMediaServerUrl/Items?ParentId=$($slib.ItemId)&Recursive=true&Fields=ProviderIds,SeasonUserData,OriginalTitle,Path,Overview,Settings,Tags,Width,Height,MediaStreams&IncludeItemTypes=Episode&CollapseBoxSetItems=false"
                 $Querytempshow = Invoke-RestMethod -Method Get -Uri $allShowsquery -Headers $global:OtherMediaServerHeaders
                 $QuerytempEpisodes = Invoke-RestMethod -Method Get -Uri $allEpisodesquery -Headers $global:OtherMediaServerHeaders
                 $AllShows.Add($Querytempshow)


### PR DESCRIPTION
### Problem

Since Jellyfin 12, Posterizarr may only import a subset of items returned by a Jellyfin library.

Posterizarr currently queries items libraries using:

```text
/Items?ParentId=<libraryId>&Recursive=true&IncludeItemTypes=mediatype
````
like
```text
/Items?ParentId=<libraryId>&Recursive=true&IncludeItemTypes=Movie
```

without explicitly setting `CollapseBoxSetItems`.

On Jellyfin 12, movies belonging to collections/BoxSets may therefore be collapsed and omitted from the individual movie results.

In my case, Jellyfin Web reports 477 movies while the current Posterizarr-compatible API query only returns 282. Some individual movies, for example `Alice au pays des merveilles` (which is in "Films et Séries pour enfants" collection), are completely absent from that response.

### Fix

Explicitly disable BoxSet collapsing when enumerating a movie library:

```text
CollapseBoxSetItems=false
```

This makes it explicit that Posterizarr needs every individual movie, regardless of whether it belongs to a collection.

### Why this belongs client-side

Posterizarr is building a complete library inventory, so it should not depend on Jellyfin's default BoxSet collapsing behavior.

Explicitly requesting `CollapseBoxSetItems=false` also makes the query behavior deterministic across Jellyfin versions.

### Testing

Before:

```text
GET /Items?ParentId=<id>&Recursive=true&IncludeItemTypes=Movie

282 movies returned
```

After:

```text
GET /Items?ParentId=<id>&Recursive=true&IncludeItemTypes=Movie&CollapseBoxSetItems=false

477 movies returned
```

Movies previously missing from the result are returned again.